### PR TITLE
use .appimage instead of .deb

### DIFF
--- a/components/DownloadLinks.vue
+++ b/components/DownloadLinks.vue
@@ -10,7 +10,7 @@ const baseUrl = "https://github.com/franciscoBSalgueiro/en-croissant/releases/do
 const links = ref([
   {
     name: "Linux",
-    url: `${baseUrl}/v${version}/en-croissant_${version}_amd64.deb`,
+    url: `${baseUrl}/v${version}/en-croissant_${version}_amd64.AppImage`,
   },
   {
     name: "Windows",


### PR DESCRIPTION
in compatibility issues and the lack of some random system lib missing 
it's better to use appimage as the face