### PR TITLE
Update download.md to include link to Pi-Apps

### DIFF
--- a/download.md
+++ b/download.md
@@ -21,7 +21,7 @@ import DownloadLinks from './components/DownloadLinks.vue'
 
 <DownloadLinks />
 
-<div class="source-link">
+<div class="pi-apps-link">
   Also available from <a href="https://pi-apps.io/" target="_blank" rel="noreferrer">Pi-Apps</a>.
 </div>
 
@@ -52,12 +52,19 @@ h3 {
   margin-top: 0;
 }
 
-.source-link {
+.pi-apps-link {
   text-align: center;
   margin-top: 2rem;
   color: var(--vp-c-text-2);
   padding-top: 2rem;
   border-top: 1px solid var(--vp-c-divider);
+}
+
+.source-link {
+  text-align: center;
+  margin-top: 0.5rem;
+  color: var(--vp-c-text-2);
+  padding-top: 0.5rem;
 }
 
 a {

--- a/download.md
+++ b/download.md
@@ -22,6 +22,10 @@ import DownloadLinks from './components/DownloadLinks.vue'
 <DownloadLinks />
 
 <div class="source-link">
+  Also available from <a href="https://pi-apps.io/" target="_blank" rel="noreferrer">Pi-Apps</a>.
+</div>
+
+<div class="source-link">
   Want to build from source? Check out the <a href="https://github.com/franciscoBSalgueiro/en-croissant" target="_blank" rel="noreferrer">GitHub repository</a>.
 </div>
 


### PR DESCRIPTION
I have just updated the download page so that it has a link to Pi-Apps. Here is a screenshot of what the download page would look like after this update:
<img width="1920" height="1080" alt="Screenshot from 2026-03-28 20-41-28" src="https://github.com/user-attachments/assets/37873983-b3aa-475b-a78c-b0b9b37d9847" />
Thanks, Alex